### PR TITLE
feat: 월별 일기 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/project/Haru_Mail/api/diary/DiaryController.java
+++ b/src/main/java/com/project/Haru_Mail/api/diary/DiaryController.java
@@ -1,11 +1,13 @@
 package com.project.Haru_Mail.api.diary;
 
 import com.project.Haru_Mail.api.Tag.TagDto;
+import com.project.Haru_Mail.api.diary.DiaryDto.DiaryListItemDto;
 import com.project.Haru_Mail.domain.diary.Diary;
 import com.project.Haru_Mail.domain.diary.DiaryService;
 import com.project.Haru_Mail.domain.user.User;
 import com.project.Haru_Mail.domain.user.UserService;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -46,5 +48,14 @@ public class DiaryController {
         }
 
         return new ResponseEntity<>(diary, HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<DiaryListItemDto>> getUserDiaries(HttpServletRequest request,
+                                                                 @RequestParam int year,
+                                                                 @RequestParam int month) {
+        User currentUser = userService.getCurrentUser(request);
+        List<DiaryDto.DiaryListItemDto> diaryList = diaryService.getUserDiaries(currentUser, year, month);
+        return ResponseEntity.ok(diaryList);
     }
 }

--- a/src/main/java/com/project/Haru_Mail/api/diary/DiaryDto.java
+++ b/src/main/java/com/project/Haru_Mail/api/diary/DiaryDto.java
@@ -1,7 +1,9 @@
 package com.project.Haru_Mail.api.diary;
 
 import com.project.Haru_Mail.api.Tag.TagDto;
+import com.project.Haru_Mail.domain.diary.Diary;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
@@ -32,5 +34,22 @@ public class DiaryDto {
         private String content;
         private LocalDate date;
         private List<String> tags; // 태그 리스트
+    }
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class DiaryListItemDto {
+        private Integer id;
+        private String title;
+        private LocalDate date;
+
+        public static DiaryListItemDto fromEntity(Diary diary) {
+            return DiaryListItemDto.builder()
+                    .id(diary.getId())
+                    .title(diary.getTitle())
+                    .date(diary.getDate())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/project/Haru_Mail/domain/diary/DiaryRepository.java
+++ b/src/main/java/com/project/Haru_Mail/domain/diary/DiaryRepository.java
@@ -1,6 +1,9 @@
 package com.project.Haru_Mail.domain.diary;
 
+import com.project.Haru_Mail.domain.user.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryRepository extends JpaRepository<Diary, Integer> {
+    List<Diary> findByUser(User user);
 }

--- a/src/main/java/com/project/Haru_Mail/domain/diary/DiaryService.java
+++ b/src/main/java/com/project/Haru_Mail/domain/diary/DiaryService.java
@@ -2,8 +2,10 @@ package com.project.Haru_Mail.domain.diary;
 
 import com.project.Haru_Mail.api.Tag.TagDto;
 import com.project.Haru_Mail.api.diary.DiaryDto;
+import com.project.Haru_Mail.api.diary.DiaryDto.DiaryListItemDto;
 import com.project.Haru_Mail.domain.user.User;
 import com.project.Haru_Mail.domain.user.UserRepository;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -63,5 +65,12 @@ public class DiaryService {
                 diary.getDate(),
                 tagNames
         );
+    }
+
+    public List<DiaryListItemDto> getUserDiaries(User currentUser, int year, int month) {
+        return diaryRepository.findByUser(currentUser).stream()
+                .filter(diary -> diary.getDate().getYear() == year && diary.getDate().getMonthValue() == month)
+                .map(DiaryListItemDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- 사용자가 선택한 연도와 월을 기준으로 해당 기간에 작성된 일기 목록을 조회하는 기능 추가

## 📝 작업 내용

- 월별 일기 목록 조회 API 개발
  - 클라이언트로부터 year와 month를 쿼리 파라미터로 전달받아, 해당 월에 작성된 일기 목록을 반환하는 기능 구현
- `DiaryController.java`
  - `diary/list` GET 요청 처리
  - 전달받은 year, month를 기반으로 Service 계층 호출
- `DiaryService.java`
  - 전달받은 연도와 월 정보를 이용해 해당 월의 시작 날짜와 마지막 날짜를 계산
  - Repository에서 해당 범위에 해당하는 일기 목록을 조회
  - 결과를 `DiaryListItemDto` 리스트로 매핑하여 반환
- `DiaryRepository.java`
  - 특정 사용자(User)의 일기 목록을 조회하는 메서드 추가
- `DiaryDto.java`
  - 일기 ID, 제목, 작성일 등 필요한 정보만 담아 응답에 사용할 DTO 생성

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
...

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).