### PR TITLE
🔧 fix: URL에서 '?' 인코딩 처리로 인한 링크 잘림 현상 해결

### DIFF
--- a/src/main/java/com/project/Haru_Mail/domain/category/CategoryRepository.java
+++ b/src/main/java/com/project/Haru_Mail/domain/category/CategoryRepository.java
@@ -3,8 +3,6 @@ package com.project.Haru_Mail.domain.category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Integer> {
 }

--- a/src/main/java/com/project/Haru_Mail/domain/diary/DiaryService.java
+++ b/src/main/java/com/project/Haru_Mail/domain/diary/DiaryService.java
@@ -16,14 +16,12 @@ import java.util.List;
 public class DiaryService {
 
     private final DiaryRepository diaryRepository;
-    private final UserRepository userRepository;
     private final TagRepository tagRepository;
 
     private final DiaryTagRepository diaryTagRepository;
 
     public DiaryService(DiaryRepository diaryRepository, UserRepository userRepository, TagRepository tagRepository, DiaryTagRepository diaryTagRepository) {
         this.diaryRepository = diaryRepository;
-        this.userRepository = userRepository;
         this.tagRepository = tagRepository;
         this.diaryTagRepository = diaryTagRepository;
     }

--- a/src/main/java/com/project/Haru_Mail/domain/diary/DiaryTagService.java
+++ b/src/main/java/com/project/Haru_Mail/domain/diary/DiaryTagService.java
@@ -1,6 +1,5 @@
 package com.project.Haru_Mail.domain.diary;
 
-import com.project.Haru_Mail.api.diary.DiaryDto;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;

--- a/src/main/java/com/project/Haru_Mail/domain/diary/TagRepository.java
+++ b/src/main/java/com/project/Haru_Mail/domain/diary/TagRepository.java
@@ -7,7 +7,5 @@ import java.util.List;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Integer> {
-    // 카테고리 ID로 태그를 조회
-    List<Tag> findByCategoryId(Integer categoryId);
     List<Tag> findByCategoryIdAndUserUserId(Integer categoryId, Long userId);
 }

--- a/src/main/resources/templates/mail/question-mail.html
+++ b/src/main/resources/templates/mail/question-mail.html
@@ -108,7 +108,7 @@
                 </a>
             </td>
             <td align="center">
-                <a th:href="@{'http://localhost:5173/editor/' + ${questionText}}"
+                <a th:href="@{'http://localhost:5173/editor/' + ${#strings.replace(questionText, '?', '%3F')}}"
                    style="background-color:#e41c1c; color:white; padding:10px 15px; text-decoration:none; border-radius:8px; font-weight:bold;">
                     일기 쓰기 ✏️
                 </a>


### PR DESCRIPTION
## 📝 작업 내용

- URL 내 `'?'` 문자가 링크를 잘라내는 문제를 해결하기 위해 `#strings.replace`를 사용해 `'?' → '%3F'`로 인코딩 처리함
- `th:text`에는 인코딩되지 않은 원본 `questionText`를 그대로 출력하여 사용자에게는 자연스럽게 보이도록 유지

- 불필요한 변수 및 어노테이션 정리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

없습니당

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email link handling to ensure special characters in diary questions are correctly encoded, preventing broken links.

- **Refactor**
  - Internal code clean-up and removal of unused methods and imports to streamline application performance. No visible changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->